### PR TITLE
With KiCad "subtract soldermask from silkscreen" issue, only first job has silkscreen

### DIFF
--- a/gerbmerge/jobs.py
+++ b/gerbmerge/jobs.py
@@ -801,6 +801,7 @@ class Job:
     # (exposure off). This prevents an unintentional draw from the end
     # of one job to the beginning of the next when a layer is repeated
     # due to panelizing.
+    fid.write('%LPD*%')
     fid.write('X%07dY%07dD02*\n' % (X, Y))
     for cmd in self.commands[layername]:
       if type(cmd) is types.TupleType:


### PR DESCRIPTION
When using the KiCad "subtract soldermask from silkscreen" option, the first job has the correct silkscreen, in subsequent jobs the silkscreen is missing.

KiCad uses LPC to subtract pads from the silkscreen, but does not reset the polarity to default afterwards. This means subsequent jobs plot in the wrong polarity.

This patch writes %LPD*% at start of each job to reset default polarity.